### PR TITLE
Improvements to Lantern of Paranoia placement mechanics.

### DIFF
--- a/src/main/java/xreliquary/items/ItemLanternOfParanoia.java
+++ b/src/main/java/xreliquary/items/ItemLanternOfParanoia.java
@@ -2,6 +2,7 @@ package xreliquary.items;
 
 import com.google.common.collect.Lists;
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockLiquid;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.Entity;
@@ -17,7 +18,9 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.EnumSkyBlock;
 import net.minecraft.world.World;
+import net.minecraftforge.fluids.IFluidBlock;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -68,6 +71,10 @@ public class ItemLanternOfParanoia extends ItemToggleable {
 			int playerY = MathHelper.floor(player.getEntityBoundingBox().minY);
 			int playerZ = MathHelper.floor(player.posZ);
 
+			BlockPos pos;
+			IBlockState state;
+			Block block;
+
 			placement:
 			for (int xDiff = -getRange(); xDiff <= getRange(); xDiff++) {
 				for (int zDiff = -getRange(); zDiff <= getRange(); zDiff++) {
@@ -75,9 +82,14 @@ public class ItemLanternOfParanoia extends ItemToggleable {
 						int x = playerX + xDiff;
 						int y = playerY + yDiff;
 						int z = playerZ + zDiff;
-						if (!player.world.isAirBlock(new BlockPos(x, y, z)))
+
+						pos = new BlockPos(x, y, z);
+						state = world.getBlockState(pos);
+						block = state.getBlock();
+
+						if (block instanceof BlockLiquid || block instanceof IFluidBlock || !block.isAir(state, world, pos) && !block.isReplaceable(world, pos))
 							continue;
-						int lightLevel = player.world.getLightFromNeighbors(new BlockPos(x, y, z));
+						int lightLevel = player.world.getLightFromNeighborsFor(EnumSkyBlock.BLOCK, pos);
 						if (lightLevel > Settings.Items.LanternOfParanoia.minLightLevel)
 							continue;
 						if (tryToPlaceTorchAround(stack, x, y, z, player, world))

--- a/src/main/java/xreliquary/items/ItemLanternOfParanoia.java
+++ b/src/main/java/xreliquary/items/ItemLanternOfParanoia.java
@@ -71,10 +71,6 @@ public class ItemLanternOfParanoia extends ItemToggleable {
 			int playerY = MathHelper.floor(player.getEntityBoundingBox().minY);
 			int playerZ = MathHelper.floor(player.posZ);
 
-			BlockPos pos;
-			IBlockState state;
-			Block block;
-
 			placement:
 			for (int xDiff = -getRange(); xDiff <= getRange(); xDiff++) {
 				for (int zDiff = -getRange(); zDiff <= getRange(); zDiff++) {
@@ -83,13 +79,13 @@ public class ItemLanternOfParanoia extends ItemToggleable {
 						int y = playerY + yDiff;
 						int z = playerZ + zDiff;
 
-						pos = new BlockPos(x, y, z);
-						state = world.getBlockState(pos);
-						block = state.getBlock();
+						BlockPos pos = new BlockPos(x, y, z);
+						IBlockState state = world.getBlockState(pos);
+						Block block = state.getBlock();
 
 						if (block instanceof BlockLiquid || block instanceof IFluidBlock || !block.isAir(state, world, pos) && !block.isReplaceable(world, pos))
 							continue;
-						int lightLevel = player.world.getLightFromNeighborsFor(EnumSkyBlock.BLOCK, pos);
+						int lightLevel = player.world.getLightFor(EnumSkyBlock.BLOCK, pos);
 						if (lightLevel > Settings.Items.LanternOfParanoia.minLightLevel)
 							continue;
 						if (tryToPlaceTorchAround(stack, x, y, z, player, world))


### PR DESCRIPTION
The two main issues I've had with the Lantern of Paranoia (which I otherwise love), is that it only works at night. Additionally, if you happen to be in a snow-heavy biome, it will never place torches on snow blocks. 

This patch addresses both of these issues:

1) The Lantern of Paranoia will now place light on blocks below the set light level regardless of sky light. This allows the item to be used efficiently during the day.
2) It will attempt to place torches on replaceable, non-liquid blocks in addition to air blocks. This allows the lantern to be used in snowy areas without too much of a malus.

I've tested it but not against your current dev branch. As far as I'm aware it appears to function properly. I extrapolated out some of the BlockPos creations into just one variable to prevent multiple calls, and simplified the world.isAir() call into the base block.isAir() call.

Hopefully nothing too majorly wrong!