### PR TITLE
Bullet Entity targetting improvements

### DIFF
--- a/src/main/java/xreliquary/entities/shot/EntityShotBase.java
+++ b/src/main/java/xreliquary/entities/shot/EntityShotBase.java
@@ -474,7 +474,7 @@ public abstract class EntityShotBase extends Entity implements IProjectile {
 			Entity currentTarget = (Entity) iTarget.next();
 
 			String entityName = EntityList.getEntityString(currentTarget);
-			if(ArrayUtils.contains(huntableEntitiesBlacklist, entityName) || (currentTarget == shootingEntity) || (currentTarget.isDead))
+			if(ArrayUtils.contains(huntableEntitiesBlacklist, entityName) || (currentTarget == shootingEntity) || (currentTarget.isDead || (currentTarget instanceof EntityLivingBase && ((EntityLivingBase) currentTarget).getHealth() <= 0)))
 				continue;
 			// goes for the closest thing it can
 			if(this.getDistance(currentTarget) < closestDistance) {


### PR DESCRIPTION
Makes the bullet move onto the next target as soon as the active one has 0 health instead of hovering around while the death animation is occuring.

This does significantly speed up the effectiveness of the bullet so if this makes it too powerfull I understand why you'd want to deny the PR.

I wanted to also fix the issue of bullets sometimes getting stuck trying to hit a target but endlessly failing, but once I isolated the problem down to the use of calculateIntercept in EntityShotBase I wasn't sure if I wanted to try and make sense of the method and also debug the bounding boxes used to see whats going on there, so I figured i'd at least mention it here.