### PR TITLE
Readd Waila(Jade) integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,9 @@ dependencies {
     compileOnly fg.deobf("top.theillusivec4.curios:curios-forge:${project.minecraft_version}-${curios_version}:api")
     runtimeOnly fg.deobf("top.theillusivec4.curios:curios-forge:${project.minecraft_version}-${curios_version}")
 
+    compileOnly fg.deobf("curse.maven:jade-324717:3822510")
+    runtimeOnly fg.deobf("curse.maven:jade-324717:3822510")
+
 //    compileOnly fg.deobf("curse.maven:tinkers-74072:3576393")
 //    runtimeOnly fg.deobf("curse.maven:tinkers-74072:3576393")
 //    compileOnly fg.deobf("curse.maven:mantle-74924:3576386")

--- a/src/main/java/reliquary/blocks/tile/AlkahestryAltarBlockEntity.java
+++ b/src/main/java/reliquary/blocks/tile/AlkahestryAltarBlockEntity.java
@@ -79,7 +79,11 @@ public class AlkahestryAltarBlockEntity extends BlockEntityBase {
 		return redstoneCount;
 	}
 
-	private boolean isActive() {
+	public boolean isActive() {
 		return isActive;
+	}
+
+	public int getCycleTime() {
+		return cycleTime;
 	}
 }

--- a/src/main/java/reliquary/blocks/tile/ApothecaryCauldronBlockEntity.java
+++ b/src/main/java/reliquary/blocks/tile/ApothecaryCauldronBlockEntity.java
@@ -317,6 +317,30 @@ public class ApothecaryCauldronBlockEntity extends BlockEntityBase implements IW
 		return Settings.COMMON.blocks.apothecaryCauldron.cookTime.get();
 	}
 
+	public List<MobEffectInstance> getEffects() {
+		return effects;
+	}
+
+	public boolean hasNetherwart() {
+		return hasNetherwart;
+	}
+
+	public boolean hasGunpowder() {
+		return hasGunpowder;
+	}
+
+	public boolean hasDragonBreath() {
+		return hasDragonBreath;
+	}
+
+	public int getRedstoneCount() {
+		return redstoneCount;
+	}
+
+	public int getGlowstoneCount() {
+		return glowstoneCount;
+	}
+
 	public void handleCollidingEntity(Level level, BlockPos pos, Entity collidingEntity) {
 		int l = getLiquidLevel();
 		float f = pos.getY() + (6.0F + (3 * l)) / 16.0F;

--- a/src/main/java/reliquary/blocks/tile/ApothecaryMortarBlockEntity.java
+++ b/src/main/java/reliquary/blocks/tile/ApothecaryMortarBlockEntity.java
@@ -27,7 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class ApothecaryMortarBlockEntity extends BlockEntityBase implements IWailaDataChangeIndicator {
-	private static final int PESTLE_USAGE_MAX = 5; // the number of times you have to use the pestle
+	public static final int PESTLE_USAGE_MAX = 5; // the number of times you have to use the pestle
 	// counts the number of times the player has right clicked the block
 	// arbitrarily setting the number of times the player needs to grind the
 	// materials to five.
@@ -172,5 +172,9 @@ public class ApothecaryMortarBlockEntity extends BlockEntityBase implements IWai
 
 	public void dropItems(Level level) {
 		InventoryHelper.dropInventoryItems(level, worldPosition, items);
+	}
+
+	public int getPestleUsedCounter() {
+		return pestleUsedCounter;
 	}
 }

--- a/src/main/java/reliquary/blocks/tile/PedestalBlockEntity.java
+++ b/src/main/java/reliquary/blocks/tile/PedestalBlockEntity.java
@@ -347,6 +347,14 @@ public class PedestalBlockEntity extends PassivePedestalBlockEntity implements I
 		return switchedOn;
 	}
 
+	public boolean isPowered() {
+		return powered;
+	}
+
+	public List<Long> getOnSwitches() {
+		return onSwitches;
+	}
+
 	private void setEnabled(Level level, boolean switchedOn) {
 		if (level.getBlockState(worldPosition).getBlock() instanceof PedestalBlock) {
 			level.setBlockAndUpdate(worldPosition, level.getBlockState(worldPosition).setValue(PedestalBlock.ENABLED, switchedOn));

--- a/src/main/java/reliquary/compat/jade/JadeCompat.java
+++ b/src/main/java/reliquary/compat/jade/JadeCompat.java
@@ -1,0 +1,33 @@
+package reliquary.compat.jade;
+
+import mcp.mobius.waila.api.*;
+import reliquary.blocks.AlkahestryAltarBlock;
+import reliquary.blocks.ApothecaryCauldronBlock;
+import reliquary.blocks.ApothecaryMortarBlock;
+import reliquary.blocks.PedestalBlock;
+import reliquary.blocks.tile.AlkahestryAltarBlockEntity;
+import reliquary.blocks.tile.ApothecaryMortarBlockEntity;
+import reliquary.compat.jade.provider.DataProviderAltar;
+import reliquary.compat.jade.provider.DataProviderCauldron;
+import reliquary.compat.jade.provider.DataProviderMortar;
+import reliquary.compat.jade.provider.DataProviderPedestal;
+
+@WailaPlugin
+public class JadeCompat implements IWailaPlugin {
+	@Override
+	public void registerClient(IWailaClientRegistration registration) {
+		registration.registerComponentProvider(new DataProviderMortar(), TooltipPosition.BODY, ApothecaryMortarBlock.class);
+		registration.registerComponentProvider(new DataProviderCauldron(), TooltipPosition.BODY, ApothecaryCauldronBlock.class);
+		registration.registerComponentProvider(new DataProviderAltar(), TooltipPosition.BODY, AlkahestryAltarBlock.class);
+		registration.registerComponentProvider(new DataProviderPedestal(), TooltipPosition.BODY, PedestalBlock.class);
+
+		//registration.registerIconProvider(new DataProviderCauldron(), ApothecaryCauldronBlock.class);
+		//registration.registerIconProvider(new DataProviderPedestal(), PedestalBlock.class);
+	}
+
+	@Override
+	public void register(IWailaCommonRegistration registration) {
+		registration.registerBlockDataProvider(new DataProviderMortar(), ApothecaryMortarBlockEntity.class);
+		registration.registerBlockDataProvider(new DataProviderAltar(), AlkahestryAltarBlockEntity.class);
+	}
+}

--- a/src/main/java/reliquary/compat/jade/provider/CachedBodyDataProvider.java
+++ b/src/main/java/reliquary/compat/jade/provider/CachedBodyDataProvider.java
@@ -1,0 +1,54 @@
+package reliquary.compat.jade.provider;
+
+import mcp.mobius.waila.api.BlockAccessor;
+import mcp.mobius.waila.api.IComponentProvider;
+import mcp.mobius.waila.api.ITooltip;
+import mcp.mobius.waila.api.config.IPluginConfig;
+import mcp.mobius.waila.api.ui.IElement;
+import net.minecraft.ChatFormatting;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
+import reliquary.compat.waila.provider.IWailaDataChangeIndicator;
+import reliquary.reference.Settings;
+import reliquary.util.LanguageHelper;
+
+import java.util.List;
+
+public abstract class CachedBodyDataProvider implements IComponentProvider {
+
+	private List<List<IElement>> cachedBody = null;
+	private BlockPos cachedPosition = null;
+
+	@Override
+    public void appendTooltip(ITooltip tooltip, BlockAccessor accessor, IPluginConfig pluginConfig) {
+        if(Settings.CLIENT.wailaShiftForInfo.get() && !accessor.getPlayer().isCrouching()) {
+            tooltip.add(Component.nullToEmpty(ChatFormatting.ITALIC + LanguageHelper.getLocalization("waila.reliquary.shift_for_more") + ChatFormatting.RESET));
+            return;
+		}
+
+		IWailaDataChangeIndicator changeIndicator = null;
+
+		if(accessor.getBlockEntity() instanceof IWailaDataChangeIndicator) {
+			changeIndicator = (IWailaDataChangeIndicator) accessor.getBlockEntity();
+		}
+
+		if(changeIndicator == null || cachedBody == null || cachedPosition == null || !cachedPosition.equals(accessor.getPosition()) || changeIndicator.getDataChanged()) {
+			cachedBody = getWailaBodyToCache(accessor, pluginConfig);
+			cachedPosition = accessor.getPosition();
+		}
+
+		cachedBody = updateCache(accessor, cachedBody);
+
+		for (List<IElement> line : cachedBody) {
+			tooltip.add(line);
+		}
+	}
+
+	abstract public List<List<IElement>> getWailaBodyToCache(BlockAccessor accessor, IPluginConfig config);
+
+	public List<List<IElement>> updateCache(BlockAccessor accessor, List<List<IElement>> cached)
+	{
+		return cached;
+	}
+}
+

--- a/src/main/java/reliquary/compat/jade/provider/CachedBodyDataProvider.java
+++ b/src/main/java/reliquary/compat/jade/provider/CachedBodyDataProvider.java
@@ -26,6 +26,7 @@ public abstract class CachedBodyDataProvider implements IComponentProvider {
             tooltip.add(Component.nullToEmpty(ChatFormatting.ITALIC + LanguageHelper.getLocalization("waila.reliquary.shift_for_more") + ChatFormatting.RESET));
             return;
 		}
+		beforeAppending(tooltip, accessor, pluginConfig);
 
 		IWailaDataChangeIndicator changeIndicator = null;
 
@@ -43,6 +44,8 @@ public abstract class CachedBodyDataProvider implements IComponentProvider {
 		for (List<IElement> line : cachedBody) {
 			tooltip.add(line);
 		}
+
+		afterAppending(tooltip, accessor, pluginConfig);
 	}
 
 	abstract public List<List<IElement>> getWailaBodyToCache(IElementHelper helper, BlockAccessor accessor, IPluginConfig config);
@@ -50,6 +53,14 @@ public abstract class CachedBodyDataProvider implements IComponentProvider {
 	public List<List<IElement>> updateCache(IElementHelper helper, BlockAccessor accessor, List<List<IElement>> cached)
 	{
 		return cached;
+	}
+
+	public void beforeAppending(ITooltip tooltip, BlockAccessor accessor, IPluginConfig pluginConfig)
+	{
+	}
+
+	public void afterAppending(ITooltip tooltip, BlockAccessor accessor, IPluginConfig pluginConfig)
+	{
 	}
 }
 

--- a/src/main/java/reliquary/compat/jade/provider/CachedBodyDataProvider.java
+++ b/src/main/java/reliquary/compat/jade/provider/CachedBodyDataProvider.java
@@ -5,6 +5,7 @@ import mcp.mobius.waila.api.IComponentProvider;
 import mcp.mobius.waila.api.ITooltip;
 import mcp.mobius.waila.api.config.IPluginConfig;
 import mcp.mobius.waila.api.ui.IElement;
+import mcp.mobius.waila.api.ui.IElementHelper;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
@@ -33,20 +34,20 @@ public abstract class CachedBodyDataProvider implements IComponentProvider {
 		}
 
 		if(changeIndicator == null || cachedBody == null || cachedPosition == null || !cachedPosition.equals(accessor.getPosition()) || changeIndicator.getDataChanged()) {
-			cachedBody = getWailaBodyToCache(accessor, pluginConfig);
+			cachedBody = getWailaBodyToCache(tooltip.getElementHelper(), accessor, pluginConfig);
 			cachedPosition = accessor.getPosition();
 		}
 
-		cachedBody = updateCache(accessor, cachedBody);
+		cachedBody = updateCache(tooltip.getElementHelper(), accessor, cachedBody);
 
 		for (List<IElement> line : cachedBody) {
 			tooltip.add(line);
 		}
 	}
 
-	abstract public List<List<IElement>> getWailaBodyToCache(BlockAccessor accessor, IPluginConfig config);
+	abstract public List<List<IElement>> getWailaBodyToCache(IElementHelper helper, BlockAccessor accessor, IPluginConfig config);
 
-	public List<List<IElement>> updateCache(BlockAccessor accessor, List<List<IElement>> cached)
+	public List<List<IElement>> updateCache(IElementHelper helper, BlockAccessor accessor, List<List<IElement>> cached)
 	{
 		return cached;
 	}

--- a/src/main/java/reliquary/compat/jade/provider/DataProviderAltar.java
+++ b/src/main/java/reliquary/compat/jade/provider/DataProviderAltar.java
@@ -6,17 +6,16 @@ import mcp.mobius.waila.api.IServerDataProvider;
 import mcp.mobius.waila.api.ITooltip;
 import mcp.mobius.waila.api.config.IPluginConfig;
 import mcp.mobius.waila.api.ui.IElement;
-import mcp.mobius.waila.impl.ui.ItemStackElement;
-import mcp.mobius.waila.impl.ui.TextElement;
+import mcp.mobius.waila.api.ui.IElementHelper;
 import net.minecraft.ChatFormatting;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TextComponent;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.phys.Vec2;
 import org.jetbrains.annotations.Nullable;
 import reliquary.blocks.AlkahestryAltarBlock;
 import reliquary.blocks.tile.AlkahestryAltarBlockEntity;
@@ -39,16 +38,23 @@ public class DataProviderAltar implements IComponentProvider, IServerDataProvide
             return;
         }
 
-        if(!(accessor.getBlock() instanceof AlkahestryAltarBlock && accessor.getBlockEntity() instanceof AlkahestryAltarBlockEntity))
+        if(!(accessor.getBlock() instanceof AlkahestryAltarBlock &&
+                accessor.getBlockEntity() instanceof AlkahestryAltarBlockEntity altar))
             return;
 
-        AlkahestryAltarBlockEntity altar = (AlkahestryAltarBlockEntity) accessor.getBlockEntity();
-
+        IElementHelper helper = tooltip.getElementHelper();
         if(!altar.isActive()) {
             tooltip.add(Component.nullToEmpty(ChatFormatting.RED + LanguageHelper.getLocalization("waila.reliquary.altar.inactive") + ChatFormatting.RESET));
+
+            Vec2 delta = new Vec2(0, -4);
+            IElement redstoneIcon = helper.item(Items.REDSTONE.getDefaultInstance(), JadeHelper.ITEM_ICON_SCALE);
+            IElement requirementText = helper.text(new TextComponent(String.format("%d / %d", altar.getRedstoneCount(), Settings.COMMON.blocks.altar.redstoneCost.get())));
+            redstoneIcon.size(redstoneIcon.getSize().add(delta)).translate(delta);
+            requirementText.size(requirementText.getSize().add(delta)).translate(delta.add(new Vec2(0, (redstoneIcon.getSize().y - requirementText.getSize().y) / 2)));
+
             tooltip.add(List.of(
-                    ItemStackElement.of(new ItemStack(Items.REDSTONE, 1), JadeHelper.ITEM_ICON_SCALE),
-                    new TextElement(new TextComponent(String.format("%d / %d", altar.getRedstoneCount(), Settings.COMMON.blocks.altar.redstoneCost.get())))
+                    redstoneIcon,
+                    requirementText
             ));
             return;
         }

--- a/src/main/java/reliquary/compat/jade/provider/DataProviderAltar.java
+++ b/src/main/java/reliquary/compat/jade/provider/DataProviderAltar.java
@@ -1,0 +1,67 @@
+package reliquary.compat.jade.provider;
+
+import mcp.mobius.waila.api.BlockAccessor;
+import mcp.mobius.waila.api.IComponentProvider;
+import mcp.mobius.waila.api.IServerDataProvider;
+import mcp.mobius.waila.api.ITooltip;
+import mcp.mobius.waila.api.config.IPluginConfig;
+import mcp.mobius.waila.api.ui.IElement;
+import mcp.mobius.waila.impl.ui.ItemStackElement;
+import mcp.mobius.waila.impl.ui.TextElement;
+import net.minecraft.ChatFormatting;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.TextComponent;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import org.jetbrains.annotations.Nullable;
+import reliquary.blocks.AlkahestryAltarBlock;
+import reliquary.blocks.tile.AlkahestryAltarBlockEntity;
+import reliquary.reference.Settings;
+import reliquary.util.LanguageHelper;
+
+import java.text.SimpleDateFormat;
+import java.util.List;
+
+public class DataProviderAltar implements IComponentProvider, IServerDataProvider<BlockEntity> {
+    @Override
+    public @Nullable IElement getIcon(BlockAccessor accessor, IPluginConfig config, IElement currentIcon) {
+        return IComponentProvider.super.getIcon(accessor, config, currentIcon);
+    }
+
+    @Override
+    public void appendTooltip(ITooltip tooltip, BlockAccessor accessor, IPluginConfig pluginConfig) {
+        if(Settings.CLIENT.wailaShiftForInfo.get() && !accessor.getPlayer().isCrouching()) {
+            tooltip.add(Component.nullToEmpty(ChatFormatting.ITALIC + LanguageHelper.getLocalization("waila.reliquary.shift_for_more") + ChatFormatting.RESET));
+            return;
+        }
+
+        if(!(accessor.getBlock() instanceof AlkahestryAltarBlock && accessor.getBlockEntity() instanceof AlkahestryAltarBlockEntity))
+            return;
+
+        AlkahestryAltarBlockEntity altar = (AlkahestryAltarBlockEntity) accessor.getBlockEntity();
+
+        if(!altar.isActive()) {
+            tooltip.add(Component.nullToEmpty(ChatFormatting.RED + LanguageHelper.getLocalization("waila.reliquary.altar.inactive") + ChatFormatting.RESET));
+            tooltip.add(List.of(
+                    ItemStackElement.of(new ItemStack(Items.REDSTONE, 1), JadeHelper.ITEM_ICON_SCALE),
+                    new TextElement(new TextComponent(String.format("%d / %d", altar.getRedstoneCount(), Settings.COMMON.blocks.altar.redstoneCost.get())))
+            ));
+            return;
+        }
+
+        tooltip.add(Component.nullToEmpty(ChatFormatting.GREEN + LanguageHelper.getLocalization("waila.reliquary.altar.active")));
+        int cycleTime = accessor.getServerData().getInt("cycleTime"); // altar.getCycleTime(
+        tooltip.add(Component.nullToEmpty(LanguageHelper.getLocalization("waila.reliquary.altar.time_remaining", new SimpleDateFormat("mm:ss").format(cycleTime * 50))));
+    }
+
+    @Override
+    public void appendServerData(CompoundTag data, ServerPlayer player, Level world, BlockEntity t, boolean showDetails) {
+        // isActive and redstoneCount is synced, so only cycle time needs to be synced here
+        AlkahestryAltarBlockEntity be = (AlkahestryAltarBlockEntity) t;
+        data.putInt("cycleTime", be.getCycleTime());
+    }
+}

--- a/src/main/java/reliquary/compat/jade/provider/DataProviderCauldron.java
+++ b/src/main/java/reliquary/compat/jade/provider/DataProviderCauldron.java
@@ -1,0 +1,106 @@
+package reliquary.compat.jade.provider;
+
+import mcp.mobius.waila.api.BlockAccessor;
+import mcp.mobius.waila.api.config.IPluginConfig;
+import mcp.mobius.waila.api.ui.IElement;
+import mcp.mobius.waila.impl.ui.*;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.material.Fluids;
+import net.minecraftforge.fluids.FluidAttributes;
+import net.minecraftforge.fluids.FluidStack;
+import reliquary.blocks.ApothecaryCauldronBlock;
+import reliquary.blocks.tile.ApothecaryCauldronBlockEntity;
+import reliquary.util.potions.XRPotionHelper;
+import snownee.jade.VanillaPlugin;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class DataProviderCauldron extends CachedBodyDataProvider {
+	@Override
+    public List<List<IElement>> getWailaBodyToCache(BlockAccessor accessor, IPluginConfig config) {
+		List<List<IElement>> lines = new ArrayList<>();
+
+		if(!(accessor.getBlock() instanceof ApothecaryCauldronBlock &&
+				accessor.getBlockEntity() instanceof ApothecaryCauldronBlockEntity cauldron))
+			return List.of();
+
+		if(cauldron.getEffects().isEmpty())
+			return List.of();
+
+		List<IElement> ingredientHints = new ArrayList<>();
+		if(!cauldron.hasNetherwart()) {
+			ingredientHints.add(ItemStackElement.of(Items.NETHER_WART.getDefaultInstance(), JadeHelper.ITEM_ICON_SCALE, JadeHelper.MISSING));
+		}
+		else {
+			ingredientHints.add(ItemStackElement.of(Items.NETHER_WART.getDefaultInstance(), JadeHelper.ITEM_ICON_SCALE, JadeHelper.SATISFIED));
+		}
+
+
+		if(cauldron.hasDragonBreath()) {
+			if(!cauldron.hasGunpowder()) {
+				ingredientHints.add(ItemStackElement.of(Items.GUNPOWDER.getDefaultInstance(), JadeHelper.ITEM_ICON_SCALE, JadeHelper.MISSING));
+			}
+			else {
+				ingredientHints.add(ItemStackElement.of(Items.GUNPOWDER.getDefaultInstance(), JadeHelper.ITEM_ICON_SCALE, JadeHelper.SATISFIED));
+			}
+			ingredientHints.add(ItemStackElement.of(Items.DRAGON_BREATH.getDefaultInstance(), JadeHelper.ITEM_ICON_SCALE, JadeHelper.SATISFIED));
+		}
+
+		lines.add(ingredientHints);
+
+		List<IElement> ingredients1 = new ArrayList<>();
+		if(cauldron.getRedstoneCount() > 0) {
+			ItemStack stack = new ItemStack(Items.REDSTONE, cauldron.getRedstoneCount());
+			ingredients1.add(ItemStackElement.of(stack));
+		}
+		if(cauldron.getGlowstoneCount() > 0) {
+			ItemStack stack = new ItemStack(Items.GLOWSTONE_DUST, cauldron.getGlowstoneCount());
+			ingredients1.add(ItemStackElement.of(stack));
+		}
+		lines.add(ingredients1);
+
+		FluidStack fluidPlaceHolder = new FluidStack(Fluids.WATER, FluidAttributes.BUCKET_VOLUME * cauldron.getLiquidLevel() / 3);
+		Component potionType;
+		if (cauldron.hasDragonBreath()) {
+			potionType = new TranslatableComponent("waila.reliquary.cauldron.lingering");
+		}
+		else if(cauldron.hasGunpowder()) {
+			potionType = new TranslatableComponent("waila.reliquary.cauldron.splash");
+		} else {
+			potionType = new TranslatableComponent("waila.reliquary.cauldron.potion");
+		}
+		lines.add(createTankLine(fluidPlaceHolder, FluidAttributes.BUCKET_VOLUME, potionType));
+
+		List<Component> components = new ArrayList<>();
+		XRPotionHelper.addPotionTooltip(cauldron.getEffects(), components);
+		lines.add(components.stream().map(TextElement::new).collect(Collectors.toList()));
+		return lines;
+	}
+
+	public static List<IElement> createTankLine(FluidStack fluidStack, int capacity, Component displayName) {
+		if (displayName == Component.EMPTY) {
+			displayName = fluidStack.getDisplayName();
+		}
+		if (capacity <= 0)
+			return List.of();
+		Component text;
+		if (fluidStack.isEmpty()) {
+			text = new TranslatableComponent("jade.fluid.empty");
+		} else {
+			String amountText = VanillaPlugin.getDisplayHelper().humanReadableNumber(fluidStack.getAmount(), "B", true);
+			text = new TranslatableComponent("jade.fluid", displayName, amountText);
+		}
+		ProgressStyle progressStyle = new ProgressStyle();
+		progressStyle.overlay(new FluidStackElement(fluidStack));
+
+		BorderStyle borderStyle = new BorderStyle();
+
+		ProgressElement tank = new ProgressElement((float) fluidStack.getAmount() / capacity, text, progressStyle, borderStyle);
+		return List.of(tank);
+	}
+}

--- a/src/main/java/reliquary/compat/jade/provider/DataProviderCauldron.java
+++ b/src/main/java/reliquary/compat/jade/provider/DataProviderCauldron.java
@@ -2,8 +2,10 @@ package reliquary.compat.jade.provider;
 
 import mcp.mobius.waila.api.BlockAccessor;
 import mcp.mobius.waila.api.config.IPluginConfig;
+import mcp.mobius.waila.api.ui.IBorderStyle;
 import mcp.mobius.waila.api.ui.IElement;
-import mcp.mobius.waila.impl.ui.*;
+import mcp.mobius.waila.api.ui.IElementHelper;
+import mcp.mobius.waila.api.ui.IProgressStyle;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.world.item.ItemStack;
@@ -22,7 +24,7 @@ import java.util.stream.Collectors;
 
 public class DataProviderCauldron extends CachedBodyDataProvider {
 	@Override
-    public List<List<IElement>> getWailaBodyToCache(BlockAccessor accessor, IPluginConfig config) {
+    public List<List<IElement>> getWailaBodyToCache(IElementHelper helper, BlockAccessor accessor, IPluginConfig config) {
 		List<List<IElement>> lines = new ArrayList<>();
 
 		if(!(accessor.getBlock() instanceof ApothecaryCauldronBlock &&
@@ -34,21 +36,21 @@ public class DataProviderCauldron extends CachedBodyDataProvider {
 
 		List<IElement> ingredientHints = new ArrayList<>();
 		if(!cauldron.hasNetherwart()) {
-			ingredientHints.add(ItemStackElement.of(Items.NETHER_WART.getDefaultInstance(), JadeHelper.ITEM_ICON_SCALE, JadeHelper.MISSING));
+			ingredientHints.add(helper.item(Items.NETHER_WART.getDefaultInstance(), JadeHelper.ITEM_ICON_SCALE, JadeHelper.MISSING));
 		}
 		else {
-			ingredientHints.add(ItemStackElement.of(Items.NETHER_WART.getDefaultInstance(), JadeHelper.ITEM_ICON_SCALE, JadeHelper.SATISFIED));
+			ingredientHints.add(helper.item(Items.NETHER_WART.getDefaultInstance(), JadeHelper.ITEM_ICON_SCALE, JadeHelper.SATISFIED));
 		}
 
 
 		if(cauldron.hasDragonBreath()) {
 			if(!cauldron.hasGunpowder()) {
-				ingredientHints.add(ItemStackElement.of(Items.GUNPOWDER.getDefaultInstance(), JadeHelper.ITEM_ICON_SCALE, JadeHelper.MISSING));
+				ingredientHints.add(helper.item(Items.GUNPOWDER.getDefaultInstance(), JadeHelper.ITEM_ICON_SCALE, JadeHelper.MISSING));
 			}
 			else {
-				ingredientHints.add(ItemStackElement.of(Items.GUNPOWDER.getDefaultInstance(), JadeHelper.ITEM_ICON_SCALE, JadeHelper.SATISFIED));
+				ingredientHints.add(helper.item(Items.GUNPOWDER.getDefaultInstance(), JadeHelper.ITEM_ICON_SCALE, JadeHelper.SATISFIED));
 			}
-			ingredientHints.add(ItemStackElement.of(Items.DRAGON_BREATH.getDefaultInstance(), JadeHelper.ITEM_ICON_SCALE, JadeHelper.SATISFIED));
+			ingredientHints.add(helper.item(Items.DRAGON_BREATH.getDefaultInstance(), JadeHelper.ITEM_ICON_SCALE, JadeHelper.SATISFIED));
 		}
 
 		lines.add(ingredientHints);
@@ -56,11 +58,11 @@ public class DataProviderCauldron extends CachedBodyDataProvider {
 		List<IElement> ingredients1 = new ArrayList<>();
 		if(cauldron.getRedstoneCount() > 0) {
 			ItemStack stack = new ItemStack(Items.REDSTONE, cauldron.getRedstoneCount());
-			ingredients1.add(ItemStackElement.of(stack));
+			ingredients1.add(helper.item(stack));
 		}
 		if(cauldron.getGlowstoneCount() > 0) {
 			ItemStack stack = new ItemStack(Items.GLOWSTONE_DUST, cauldron.getGlowstoneCount());
-			ingredients1.add(ItemStackElement.of(stack));
+			ingredients1.add(helper.item(stack));
 		}
 		lines.add(ingredients1);
 
@@ -74,15 +76,15 @@ public class DataProviderCauldron extends CachedBodyDataProvider {
 		} else {
 			potionType = new TranslatableComponent("waila.reliquary.cauldron.potion");
 		}
-		lines.add(createTankLine(fluidPlaceHolder, FluidAttributes.BUCKET_VOLUME, potionType));
+		lines.add(createTank(helper, fluidPlaceHolder, FluidAttributes.BUCKET_VOLUME, potionType));
 
 		List<Component> components = new ArrayList<>();
 		XRPotionHelper.addPotionTooltip(cauldron.getEffects(), components);
-		lines.add(components.stream().map(TextElement::new).collect(Collectors.toList()));
+		lines.add(components.stream().map(helper::text).collect(Collectors.toList()));
 		return lines;
 	}
 
-	public static List<IElement> createTankLine(FluidStack fluidStack, int capacity, Component displayName) {
+	public static List<IElement> createTank(IElementHelper helper, FluidStack fluidStack, int capacity, Component displayName) {
 		if (displayName == Component.EMPTY) {
 			displayName = fluidStack.getDisplayName();
 		}
@@ -95,12 +97,12 @@ public class DataProviderCauldron extends CachedBodyDataProvider {
 			String amountText = VanillaPlugin.getDisplayHelper().humanReadableNumber(fluidStack.getAmount(), "B", true);
 			text = new TranslatableComponent("jade.fluid", displayName, amountText);
 		}
-		ProgressStyle progressStyle = new ProgressStyle();
-		progressStyle.overlay(new FluidStackElement(fluidStack));
+		IProgressStyle progressStyle = helper.progressStyle();
+		progressStyle.overlay(helper.fluid(fluidStack));
 
-		BorderStyle borderStyle = new BorderStyle();
+		IBorderStyle borderStyle = helper.borderStyle();
 
-		ProgressElement tank = new ProgressElement((float) fluidStack.getAmount() / capacity, text, progressStyle, borderStyle);
+		IElement tank = helper.progress((float) fluidStack.getAmount() / capacity, text, progressStyle, borderStyle);
 		return List.of(tank);
 	}
 }

--- a/src/main/java/reliquary/compat/jade/provider/DataProviderMortar.java
+++ b/src/main/java/reliquary/compat/jade/provider/DataProviderMortar.java
@@ -4,9 +4,8 @@ import mcp.mobius.waila.api.BlockAccessor;
 import mcp.mobius.waila.api.IServerDataProvider;
 import mcp.mobius.waila.api.config.IPluginConfig;
 import mcp.mobius.waila.api.ui.IElement;
-import mcp.mobius.waila.impl.ui.ItemStackElement;
+import mcp.mobius.waila.api.ui.IElementHelper;
 import mcp.mobius.waila.impl.ui.ProgressArrowElement;
-import mcp.mobius.waila.impl.ui.TextElement;
 import net.minecraft.core.NonNullList;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
@@ -28,7 +27,7 @@ public class DataProviderMortar extends CachedBodyDataProvider implements IServe
     private List<MobEffectInstance> effects;
 
     @Override
-    public List<List<IElement>> getWailaBodyToCache(BlockAccessor accessor, IPluginConfig config) {
+    public List<List<IElement>> getWailaBodyToCache(IElementHelper helper, BlockAccessor accessor, IPluginConfig config) {
         List<List<IElement>> lines = new ArrayList<>();
 
         if(!(accessor.getBlock() instanceof ApothecaryMortarBlock &&
@@ -40,7 +39,7 @@ public class DataProviderMortar extends CachedBodyDataProvider implements IServe
         List<PotionIngredient> potionIngredients = new ArrayList<>();
         for (ItemStack ingredientStack : ingredientStacks) {
             if (ingredientStack.isEmpty()) continue;
-            ingredients.add(ItemStackElement.of(ingredientStack));
+            ingredients.add(helper.item(ingredientStack));
             potionIngredients.add(XRPotionHelper.getIngredient(ingredientStack).get());
         }
         lines.add(ingredients);
@@ -50,30 +49,30 @@ public class DataProviderMortar extends CachedBodyDataProvider implements IServe
 
         if(!effects.isEmpty()) {
             int pestleUsedCounter = accessor.getServerData().getInt("pestleUsedCounter");
-            lines.add(createPestleProgress(pestleUsedCounter));
+            lines.add(createPestleProgress(helper, pestleUsedCounter));
 
             XRPotionHelper.addPotionTooltip(effects, effectTooltips);
-            lines.addAll(effectTooltips.stream().map(text -> List.of((IElement) new TextElement(text))).toList());
+            lines.addAll(effectTooltips.stream().map(text -> List.of(helper.text(text))).toList());
         }
         return lines;
     }
 
-    public List<IElement> createPestleProgress(int pestleUsedCounter)
+    public List<IElement> createPestleProgress(IElementHelper helper, int pestleUsedCounter)
     {
         ItemStack stack = ModItems.POTION_ESSENCE.get().getDefaultInstance();
         XRPotionHelper.addPotionEffectsToStack(stack, effects);
 
         return List.of(
                 new ProgressArrowElement((float)pestleUsedCounter / ApothecaryMortarBlockEntity.PESTLE_USAGE_MAX),
-                ItemStackElement.of(stack)
+                helper.item(stack)
         );
     }
 
     @Override
-    public List<List<IElement>> updateCache(BlockAccessor accessor, List<List<IElement>> cached) {
+    public List<List<IElement>> updateCache(IElementHelper helper, BlockAccessor accessor, List<List<IElement>> cached) {
         if (cached.size() > 1) {
             int pestleUsedCounter = accessor.getServerData().getInt("pestleUsedCounter");
-            cached.set(1, createPestleProgress(pestleUsedCounter));
+            cached.set(1, createPestleProgress(helper, pestleUsedCounter));
         }
         return cached;
     }

--- a/src/main/java/reliquary/compat/jade/provider/DataProviderMortar.java
+++ b/src/main/java/reliquary/compat/jade/provider/DataProviderMortar.java
@@ -1,0 +1,86 @@
+package reliquary.compat.jade.provider;
+
+import mcp.mobius.waila.api.BlockAccessor;
+import mcp.mobius.waila.api.IServerDataProvider;
+import mcp.mobius.waila.api.config.IPluginConfig;
+import mcp.mobius.waila.api.ui.IElement;
+import mcp.mobius.waila.impl.ui.ItemStackElement;
+import mcp.mobius.waila.impl.ui.ProgressArrowElement;
+import mcp.mobius.waila.impl.ui.TextElement;
+import net.minecraft.core.NonNullList;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import reliquary.blocks.ApothecaryMortarBlock;
+import reliquary.blocks.tile.ApothecaryMortarBlockEntity;
+import reliquary.init.ModItems;
+import reliquary.util.potions.PotionIngredient;
+import reliquary.util.potions.XRPotionHelper;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DataProviderMortar extends CachedBodyDataProvider implements IServerDataProvider<BlockEntity> {
+    private List<MobEffectInstance> effects;
+
+    @Override
+    public List<List<IElement>> getWailaBodyToCache(BlockAccessor accessor, IPluginConfig config) {
+        List<List<IElement>> lines = new ArrayList<>();
+
+        if(!(accessor.getBlock() instanceof ApothecaryMortarBlock &&
+                accessor.getBlockEntity() instanceof ApothecaryMortarBlockEntity mortar))
+            return lines;
+
+        NonNullList<ItemStack> ingredientStacks = mortar.getItemStacks();
+        List<IElement> ingredients = new ArrayList<>();
+        List<PotionIngredient> potionIngredients = new ArrayList<>();
+        for (ItemStack ingredientStack : ingredientStacks) {
+            if (ingredientStack.isEmpty()) continue;
+            ingredients.add(ItemStackElement.of(ingredientStack));
+            potionIngredients.add(XRPotionHelper.getIngredient(ingredientStack).get());
+        }
+        lines.add(ingredients);
+
+        effects = XRPotionHelper.combineIngredients(potionIngredients);
+        List<Component> effectTooltips = new ArrayList<>();
+
+        if(!effects.isEmpty()) {
+            int pestleUsedCounter = accessor.getServerData().getInt("pestleUsedCounter");
+            lines.add(createPestleProgress(pestleUsedCounter));
+
+            XRPotionHelper.addPotionTooltip(effects, effectTooltips);
+            lines.addAll(effectTooltips.stream().map(text -> List.of((IElement) new TextElement(text))).toList());
+        }
+        return lines;
+    }
+
+    public List<IElement> createPestleProgress(int pestleUsedCounter)
+    {
+        ItemStack stack = ModItems.POTION_ESSENCE.get().getDefaultInstance();
+        XRPotionHelper.addPotionEffectsToStack(stack, effects);
+
+        return List.of(
+                new ProgressArrowElement((float)pestleUsedCounter / ApothecaryMortarBlockEntity.PESTLE_USAGE_MAX),
+                ItemStackElement.of(stack)
+        );
+    }
+
+    @Override
+    public List<List<IElement>> updateCache(BlockAccessor accessor, List<List<IElement>> cached) {
+        if (cached.size() > 1) {
+            int pestleUsedCounter = accessor.getServerData().getInt("pestleUsedCounter");
+            cached.set(1, createPestleProgress(pestleUsedCounter));
+        }
+        return cached;
+    }
+
+    @Override
+    public void appendServerData(CompoundTag data, ServerPlayer player, Level world, BlockEntity t, boolean showDetails) {
+        ApothecaryMortarBlockEntity be = (ApothecaryMortarBlockEntity) t;
+        data.putInt("pestleUsedCounter", be.getPestleUsedCounter());
+    }
+}

--- a/src/main/java/reliquary/compat/jade/provider/DataProviderMortar.java
+++ b/src/main/java/reliquary/compat/jade/provider/DataProviderMortar.java
@@ -2,6 +2,7 @@ package reliquary.compat.jade.provider;
 
 import mcp.mobius.waila.api.BlockAccessor;
 import mcp.mobius.waila.api.IServerDataProvider;
+import mcp.mobius.waila.api.ITooltip;
 import mcp.mobius.waila.api.config.IPluginConfig;
 import mcp.mobius.waila.api.ui.IElement;
 import mcp.mobius.waila.api.ui.IElementHelper;
@@ -19,9 +20,11 @@ import reliquary.blocks.tile.ApothecaryMortarBlockEntity;
 import reliquary.init.ModItems;
 import reliquary.util.potions.PotionIngredient;
 import reliquary.util.potions.XRPotionHelper;
+import snownee.jade.VanillaPlugin;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 public class DataProviderMortar extends CachedBodyDataProvider implements IServerDataProvider<BlockEntity> {
     private List<MobEffectInstance> effects;
@@ -40,7 +43,7 @@ public class DataProviderMortar extends CachedBodyDataProvider implements IServe
         for (ItemStack ingredientStack : ingredientStacks) {
             if (ingredientStack.isEmpty()) continue;
             ingredients.add(helper.item(ingredientStack));
-            potionIngredients.add(XRPotionHelper.getIngredient(ingredientStack).get());
+            XRPotionHelper.getIngredient(ingredientStack).ifPresent(potionIngredients::add);
         }
         lines.add(ingredients);
 
@@ -81,5 +84,11 @@ public class DataProviderMortar extends CachedBodyDataProvider implements IServe
     public void appendServerData(CompoundTag data, ServerPlayer player, Level world, BlockEntity t, boolean showDetails) {
         ApothecaryMortarBlockEntity be = (ApothecaryMortarBlockEntity) t;
         data.putInt("pestleUsedCounter", be.getPestleUsedCounter());
+    }
+
+    @Override
+    public void beforeAppending(ITooltip tooltip, BlockAccessor accessor, IPluginConfig pluginConfig) {
+        tooltip.remove(VanillaPlugin.INVENTORY);
+        super.beforeAppending(tooltip, accessor, pluginConfig);
     }
 }

--- a/src/main/java/reliquary/compat/jade/provider/DataProviderPedestal.java
+++ b/src/main/java/reliquary/compat/jade/provider/DataProviderPedestal.java
@@ -1,0 +1,44 @@
+package reliquary.compat.jade.provider;
+
+import mcp.mobius.waila.api.BlockAccessor;
+import mcp.mobius.waila.api.IComponentProvider;
+import mcp.mobius.waila.api.ITooltip;
+import mcp.mobius.waila.api.config.IPluginConfig;
+import net.minecraft.ChatFormatting;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.world.level.block.state.BlockState;
+import reliquary.blocks.PedestalBlock;
+import reliquary.blocks.tile.PedestalBlockEntity;
+
+public class DataProviderPedestal implements IComponentProvider {
+
+    @Override
+    public void appendTooltip(ITooltip tooltip, BlockAccessor accessor, IPluginConfig pluginConfig) {
+        if(!(accessor.getBlock() instanceof PedestalBlock && accessor.getBlockEntity() instanceof PedestalBlockEntity))
+            return;
+
+        PedestalBlockEntity pedestal = (PedestalBlockEntity) accessor.getBlockEntity();
+        BlockState pedestalState = accessor.getBlockState();
+
+        if(pedestalState.getValue(PedestalBlock.ENABLED)) {
+            tooltip.add(new TranslatableComponent("tooltip.waila.state", new TranslatableComponent("tooltip.waila.state_on").withStyle(ChatFormatting.GREEN)));
+
+            if(pedestal.switchedOn()) {
+                tooltip.add(new TranslatableComponent("waila.reliquary.pedestal.switched_on"));
+            }
+            if(pedestal.isPowered()) {
+                tooltip.add(new TranslatableComponent("waila.reliquary.pedestal.redstone_powered"));
+            }
+            if(pedestal.getOnSwitches().size() > 0) {
+                for(long loc : pedestal.getOnSwitches()) {
+                    BlockPos pos = BlockPos.of(loc);
+                    tooltip.add(new TranslatableComponent("waila.reliquary.pedestal.remote_at", pos.getX(), pos.getY(), pos.getZ()));
+                }
+            }
+        } else {
+            tooltip.add(new TranslatableComponent("tooltip.waila.state", new TranslatableComponent("tooltip.waila.state_off").withStyle(ChatFormatting.RED)));
+        }
+    }
+
+}

--- a/src/main/java/reliquary/compat/jade/provider/JadeHelper.java
+++ b/src/main/java/reliquary/compat/jade/provider/JadeHelper.java
@@ -1,0 +1,9 @@
+package reliquary.compat.jade.provider;
+
+import net.minecraft.ChatFormatting;
+
+public class JadeHelper {
+    public static float ITEM_ICON_SCALE = 1F;
+    public static String MISSING = ChatFormatting.RED + "?";
+    public static String SATISFIED = ChatFormatting.GREEN + "√";
+}

--- a/src/main/java/reliquary/reference/Settings.java
+++ b/src/main/java/reliquary/reference/Settings.java
@@ -34,7 +34,7 @@ public class Settings {
 
 	public static class Client {
 		public final HudPos hudPositions;
-		final BooleanValue wailaShiftForInfo;
+		public final BooleanValue wailaShiftForInfo;
 
 		public static class HudPos {
 			public final EnumValue<HUDPosition> sojournerStaff;

--- a/src/main/java/reliquary/util/potions/XRPotionHelper.java
+++ b/src/main/java/reliquary/util/potions/XRPotionHelper.java
@@ -90,7 +90,7 @@ public class XRPotionHelper {
 	}
 
 	@OnlyIn(Dist.CLIENT)
-	private static void addPotionTooltip(List<MobEffectInstance> effects, List<Component> list) {
+	public static void addPotionTooltip(List<MobEffectInstance> effects, List<Component> list) {
 		if (!effects.isEmpty()) {
 			List<Tuple<String, AttributeModifier>> list1 = Lists.newArrayList();
 			for (MobEffectInstance potioneffect : effects) {

--- a/src/main/resources/assets/reliquary/lang/en_us.json
+++ b/src/main/resources/assets/reliquary/lang/en_us.json
@@ -358,5 +358,16 @@
     "enchantment.reliquary.severing": "Severing",
     "enchantment.reliquary.severing.desc": "Significantly increases chance of Reliquary drops",
 
-    "fluid.reliquary.xp_juice_still": "Experience"
+    "fluid.reliquary.xp_juice_still": "Experience",
+
+    "waila.reliquary.cauldron.lingering": "Lingering potion",
+    "waila.reliquary.cauldron.splash": "Splash potion",
+    "waila.reliquary.cauldron.potion": "Potion",
+    "waila.reliquary.altar.inactive": "Inactive",
+    "waila.reliquary.altar.active": "Active",
+    "waila.reliquary.altar.time_remaining": "Time remaining: %s",
+    "waila.reliquary.shift_for_more": "Hold shift for more info",
+    "waila.reliquary.pedestal.redstone_powered": "Redstone",
+    "waila.reliquary.pedestal.switched_on": "Switched",
+    "waila.reliquary.pedestal.remote_at": "Remote at: %d, %d, %d"
 }

--- a/src/main/resources/assets/reliquary/lang/ru_ru.json
+++ b/src/main/resources/assets/reliquary/lang/ru_ru.json
@@ -356,5 +356,16 @@
     "tooltip.reliquary.drain": "{{!colors.light_purple}}Нажмите Shift+ПКМ, чтобы активировать режим истощения.",
     "tooltip.reliquary.place": "{{!colors.light_purple}}Нажмите Shift+ПКМ, чтобы активировать режим размещения.",
     "tooltip.reliquary.absorb_active": "{{!colors.purple}}Автоматически поглощает {{item}}{{!colors.purple}}.",
-    "tooltip.reliquary.absorb_tear": "{{!colors.purple}}Всегда оставляет стак этого предмета в инвентаре."
+    "tooltip.reliquary.absorb_tear": "{{!colors.purple}}Всегда оставляет стак этого предмета в инвентаре.",
+
+    "waila.reliquary.cauldron.lingering": "Затяжное зелье",
+    "waila.reliquary.cauldron.splash": "Взрывное зелье",
+    "waila.reliquary.cauldron.potion": "Зелье",
+    "waila.reliquary.altar.inactive": "Неактивен",
+    "waila.reliquary.altar.active": "Активен",
+    "waila.reliquary.altar.time_remaining": "Времени осталось: %s",
+    "waila.reliquary.shift_for_more": "Удерживайте Shift для большей информации",
+    "waila.reliquary.pedestal.redstone_powered": "Redstone",
+    "waila.reliquary.pedestal.switched_on": "Switched",
+    "waila.reliquary.pedestal.remote_at": "Remote at: %d, %d, %d"
 }

--- a/src/main/resources/assets/reliquary/lang/zh_cn.json
+++ b/src/main/resources/assets/reliquary/lang/zh_cn.json
@@ -352,5 +352,16 @@
     "tooltip.reliquary.drain": "{{!colors.light_purple}}按住Shift右击切换排空模式。",
     "tooltip.reliquary.place": "{{!colors.light_purple}}按住Shift右击切换放置模式。",
     "tooltip.reliquary.absorb_active": "{{!colors.purple}}将自动吸收{{item}}{{!colors.purple}}。",
-    "tooltip.reliquary.absorb_tear": "{{!colors.purple}}总会在物品栏中保留一组物品。"
+    "tooltip.reliquary.absorb_tear": "{{!colors.purple}}总会在物品栏中保留一组物品。",
+
+    "waila.reliquary.cauldron.lingering": "滞留型药水",
+    "waila.reliquary.cauldron.splash": "喷溅型药水",
+    "waila.reliquary.cauldron.potion": "药水",
+    "waila.reliquary.altar.inactive": "未激活",
+    "waila.reliquary.altar.active": "激活",
+    "waila.reliquary.altar.time_remaining": "剩余时间: %s",
+    "waila.reliquary.shift_for_more": "按住<Shift>查看详细信息",
+    "waila.reliquary.pedestal.redstone_powered": "已被 红石 激活",
+    "waila.reliquary.pedestal.switched_on": "已被 开关 激活",
+    "waila.reliquary.pedestal.remote_at": "已被 远程 激活: %d, %d, %d"
 }


### PR DESCRIPTION
[Jade](https://www.curseforge.com/minecraft/mc-mods/jade) is a fork of [HWYLA](https://www.curseforge.com/minecraft/mc-mods/hwyla) which itself is a fork of [WAILA](https://minecraft.curseforge.com/projects/waila). This is readding Waila(Jade) integration to Reliquary. Please do let me know if any improvement is required. And thanks for your excellent work! 

### Changes

1. Changed visibility of some fields by directly changing access modifiers or creating corresponding getters.
2. Implemented CachedBodyDataProvider.
3. Implemented component provider for Apothecary Mortar, Apothecary Cauldron, Alkahestry Altar and Pedestal.

### Help needed

- [ ] Update Russian translation


### Preview

![Mortar](https://user-images.githubusercontent.com/8695716/175787511-6526debd-2add-41fa-8c26-03f501dc27f4.png)
![Cauldron](https://user-images.githubusercontent.com/8695716/175787520-c10fe077-e392-49fc-ac03-31e318d02992.png)
![Altar1](https://user-images.githubusercontent.com/8695716/175787524-9e385498-6827-4d2b-8540-e6cedc20649f.png)
![Altar2](https://user-images.githubusercontent.com/8695716/175787531-a5c40e88-d9dd-4e17-bebc-7f244aeb165e.png)
![Pedestal1](https://user-images.githubusercontent.com/8695716/175787542-6edcd848-c93a-4a8c-b38d-c4aaa12a7122.png)
![Pedestal2](https://user-images.githubusercontent.com/8695716/175787557-a67dab42-7e88-4207-ae98-30ef588dd9c1.png)