### PR TITLE
Added magicbane damage scaling factor

### DIFF
--- a/src/main/java/reliquary/items/MagicbaneItem.java
+++ b/src/main/java/reliquary/items/MagicbaneItem.java
@@ -22,6 +22,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import reliquary.Reliquary;
+import reliquary.reference.Settings;
 import reliquary.util.LanguageHelper;
 
 import javax.annotation.Nullable;
@@ -91,9 +92,14 @@ public class MagicbaneItem extends SwordItem {
 
 		ListTag enchants = stack.getEnchantmentTags();
 		int attackDamage = 4;
+		int enchantBonus = 0;
 		for (int enchant = 0; enchant < enchants.size(); enchant++) {
-			attackDamage += enchants.getCompound(enchant).getShort("lvl");
+			enchantBonus += enchants.getCompound(enchant).getShort("lvl");
 		}
+		double damageExponent = Settings.COMMON.items.magicBane.damageExponent.get();
+		enchantBonus = (int) Math.round(Math.pow(enchantBonus, damageExponent));
+		attackDamage += enchantBonus;
+
 		return ImmutableMultimap.of(
 				Attributes.ATTACK_DAMAGE, new AttributeModifier(BASE_ATTACK_DAMAGE_UUID, "Weapon modifier", attackDamage, AttributeModifier.Operation.ADDITION),
 				Attributes.ATTACK_SPEED, SPEED_ATTRIBUTE

--- a/src/main/java/reliquary/reference/Settings.java
+++ b/src/main/java/reliquary/reference/Settings.java
@@ -263,6 +263,7 @@ public class Settings {
 				infernalTear = new InfernalTearSettings(builder);
 				krakenShell = new KrakenShellSettings(builder);
 				lanternOfParanoia = new LanternOfParanoiaSettings(builder);
+				magicBane = new MagicbaneSettings(builder);
 				midasTouchstone = new MidasTouchstoneSettings(builder);
 				mobCharm = new MobCharmSettings(builder);
 				mobCharmFragment = new MobCharmFragmentSettings(builder);
@@ -810,6 +811,22 @@ public class Settings {
 					placementScanRadius = builder
 							.comment("Radius in which the lantern checks for light levels and places torches")
 							.defineInRange("placementScanRadius", 6, 1, 15);
+
+					builder.pop();
+				}
+			}
+
+			public final MagicbaneSettings magicBane;
+
+			public static class MagicbaneSettings {
+				public final DoubleValue damageExponent;
+
+				MagicbaneSettings(ForgeConfigSpec.Builder builder) {
+					builder.comment("Magicbane settings").push("magicbane");
+
+					damageExponent = builder
+							.comment("Magicbane bonus damage scaling exponent, based on total level of enchants. 1 = linear scaling, 2 = quadratic, 0.5 = square root, etc.")
+							.defineInRange("magicbaneDamageScaling", 1f, 0, 3);
 
 					builder.pop();
 				}


### PR DESCRIPTION
Due to the way many mods and modpacks add to or change the enchanting system, it can be desirable to adjust the magicbane's enchant-based damage output scaling.

This PR adds a scale factor to the config, which acts as an exponent for the total enchantment amount used for calculating magicbane damage. It defaults to 1, making it linear and therefore identical to the current magicbane behavior, but can also be adjusted upward for greater than linear scaling, or downward for less than linear scaling.