### PR TITLE
Restore Dispenser behavior for Potion & Serum projectiles

### DIFF
--- a/src/main/java/reliquary/entities/potion/AphroditePotion.java
+++ b/src/main/java/reliquary/entities/potion/AphroditePotion.java
@@ -47,6 +47,8 @@ public class AphroditePotion extends ThrownPotionBase {
 		Entity thrower = getOwner();
 		if (thrower instanceof Player player) {
 			animal.setInLove(player);
+		} else {
+			animal.setInLove(null);
 		}
 
 		for (int var3 = 0; var3 < 7; ++var3) {

--- a/src/main/java/reliquary/entities/potion/ThrownPotion.java
+++ b/src/main/java/reliquary/entities/potion/ThrownPotion.java
@@ -104,12 +104,10 @@ public class ThrownPotion extends ThrowableProjectile implements ItemSupplier {
 	}
 
 	private void spawnAreaEffectCloud(PotionContents potionContents) {
-		Entity thrower = getOwner();
-		if (!(thrower instanceof LivingEntity)) {
-			return;
+        AreaEffectCloud areaEffectCloud = new AreaEffectCloud(level(), getX(), getY(), getZ());
+		if (getOwner() instanceof LivingEntity livingEntity) {
+			areaEffectCloud.setOwner(livingEntity);
 		}
-		AreaEffectCloud areaEffectCloud = new AreaEffectCloud(level(), getX(), getY(), getZ());
-		areaEffectCloud.setOwner((LivingEntity) thrower);
 		areaEffectCloud.setRadius(3.0F);
 		areaEffectCloud.setRadiusOnUse(-0.5F);
 		areaEffectCloud.setWaitTime(10);


### PR DESCRIPTION
Despite Splash Potions, Lingering Potions, and Aphrodite's Serum being registered for dispenser behavior, I discovered that effects did not happen upon projectile impacts. These are the only two projectiles with incomplete dispenser effects, all other projectiles' effects are verified to be working as expected.