### PR TITLE
Fixed Mob Charm Fragment Looting not working (i think) [1.21.x]

### DIFF
--- a/src/main/java/reliquary/item/MobCharmRegistry.java
+++ b/src/main/java/reliquary/item/MobCharmRegistry.java
@@ -90,7 +90,7 @@ public class MobCharmRegistry {
 		}
 
 		HolderLookup.RegistryLookup<Enchantment> registrylookup = entity.level().registryAccess().lookupOrThrow(Registries.ENCHANTMENT);
-		int lootingLevel = EnchantmentHelper.getEnchantmentLevel(registrylookup.getOrThrow(Enchantments.LOOTING), entity);
+		int lootingLevel = EnchantmentHelper.getEnchantmentLevel(registrylookup.getOrThrow(Enchantments.LOOTING), (LivingEntity)evt.getSource().getEntity());
 
 		double dynamicDropChance = Config.COMMON.items.mobCharmFragment.dropChance.get() + lootingLevel * Config.COMMON.items.mobCharmFragment.lootingMultiplier.get();
 

--- a/src/main/java/reliquary/reference/Config.java
+++ b/src/main/java/reliquary/reference/Config.java
@@ -205,7 +205,7 @@ public class Config {
 					.define("chestLootEnabled", true);
 
 			dropCraftingRecipesEnabled = builder
-					.comment("Determines wheter Reliquary mob drops have crafting recipes")
+					.comment("Determines whether Reliquary mob drops have crafting recipes")
 					.define("dropCraftingRecipesEnabled", false);
 
 			mobDropsEnabled = builder


### PR DESCRIPTION
I noticed that Mob Charm Fragment looting multiplier wasn't working for me on ATM10 and I think it's because lootingLevel was not reading the correct thing.
Also a typo fix.