### PR TITLE
Add Mob Charms to registry

### DIFF
--- a/src/main/java/reliquary/item/MobCharmRegistry.java
+++ b/src/main/java/reliquary/item/MobCharmRegistry.java
@@ -71,7 +71,7 @@ public class MobCharmRegistry {
 	public static void registerDynamicCharmDefinitions() {
 		for (EntityType<?> entityType : BuiltInRegistries.ENTITY_TYPE) {
 			ResourceLocation registryName = EntityType.getKey(entityType);
-			if (!ENTITY_NAME_CHARM_DEFINITIONS.containsKey(registryName) && entityType.getCategory() == MobCategory.MONSTER && !Config.COMMON.items.mobCharm.isBlockedEntity(registryName)) {
+			if (!ENTITY_NAME_CHARM_DEFINITIONS.containsKey(registryName) && ((entityType.getCategory() == MobCategory.MONSTER && !Config.COMMON.items.mobCharm.isBlockedEntity(registryName)) || Config.COMMON.items.mobCharm.isAddEntity(registryName))) {
 				registerMobCharmDefinition(new MobCharmDefinition(entityType));
 				DYNAMICALLY_REGISTERED.add(registryName);
 			}

--- a/src/main/java/reliquary/reference/Config.java
+++ b/src/main/java/reliquary/reference/Config.java
@@ -890,6 +890,8 @@ public class Config {
 				// ? extends String is the type parameter returned from defineList so it can't be just String here
 				public final ConfigValue<List<? extends String>> entityBlockList;
 
+				public final ConfigValue<List<? extends String>> entityAddList;
+
 				@Nullable
 				private Set<ResourceLocation> entityBlockListCache = null;
 
@@ -919,6 +921,11 @@ public class Config {
 					entityBlockList = builder
 							.comment("List of hostile entities that are not supposed to have mob charms registered for them")
 							.defineList("entityBlockList", this::getDefaultEntityBlockList, () -> BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.ZOMBIE).toString() , entityName -> ((String) entityName).matches(REGISTRY_NAME_MATCHER));
+
+                    entityAddList = builder
+							.comment("List of entities that are to have mob charms registered for them that are not of HOSTILE type")
+							.defineList("entityAddList", this::getDefaultEntityAddList, () -> BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.ZOMBIE).toString() , entityName -> ((String) entityName).matches(REGISTRY_NAME_MATCHER));
+					
 					builder.pop();
 				}
 
@@ -928,6 +935,11 @@ public class Config {
 					ret.add("minecraft:wither");
 					return ret;
 				}
+
+				private List<String> getDefaultEntityAddList() {
+					List<String> ret = new ArrayList<>();
+					return ret;
+				}				
 
 				public boolean isBlockedEntity(ResourceLocation registryName) {
 					if (entityBlockListCache == null) {

--- a/src/main/java/reliquary/reference/Config.java
+++ b/src/main/java/reliquary/reference/Config.java
@@ -892,6 +892,7 @@ public class Config {
 
 				@Nullable
 				private Set<ResourceLocation> entityBlockListCache = null;
+				private Set<ResourceLocation> entiryAddListCache = null;
 
 				MobCharmSettings(ModConfigSpec.Builder builder) {
 					builder.comment("Mob Charm settings").push("mobCharm");
@@ -939,8 +940,19 @@ public class Config {
 					return entityBlockListCache.contains(registryName);
 				}
 
+				public boolean isAddEntity(ResourceLocation registryName) {
+					if (entityAddListCache == null) {
+						entityAddListCache = new HashSet<>();
+						for (String entityName : entityAddList.get()) {
+							entityAddListCache.add(ResourceLocation.parse(entityName));
+						}
+					}
+					return entityAddListCache.contains(registryName);
+				}
+
 				public void resetCache() {
 					entityBlockListCache = null;
+					entityAddListChache= null;
 				}
 			}
 

--- a/src/main/java/reliquary/reference/Config.java
+++ b/src/main/java/reliquary/reference/Config.java
@@ -924,7 +924,7 @@ public class Config {
 							.defineList("entityBlockList", this::getDefaultEntityBlockList, () -> BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.ZOMBIE).toString() , entityName -> ((String) entityName).matches(REGISTRY_NAME_MATCHER));
 
                     entityAddList = builder
-							.comment("List of entities that are to have mob charms registered for them that are not of HOSTILE type")
+							.comment("List of entities that are to have mob charms registered for them that are not of MONSTER type")
 							.defineList("entityAddList", this::getDefaultEntityAddList, () -> BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.ZOMBIE).toString() , entityName -> ((String) entityName).matches(REGISTRY_NAME_MATCHER));
 					
 					builder.pop();


### PR DESCRIPTION
Create a config list of mobs to add to the MobCharm registry that are not of type Monster.  This is mainly for pack devs to be able to easily add additional mobs.

Note: I've not fully tested this yet.